### PR TITLE
address validation in baker & fix edit depositor

### DIFF
--- a/frontend/app/src/components/OvenCard/BakerInfo.tsx
+++ b/frontend/app/src/components/OvenCard/BakerInfo.tsx
@@ -15,7 +15,8 @@ import { useFormik } from 'formik';
 import { MdInfo } from 'react-icons/md';
 import { useTranslation } from 'react-i18next';
 import * as Yup from 'yup';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { components, OptionProps } from 'react-select';
 import { useDelegates, useOvenDelegate } from '../../api/queries';
 import { useWallet } from '../../wallet/hooks';
 import Button from '../button/Button';
@@ -103,6 +104,13 @@ const BakerInfo: React.FC<{ oven: AllOvenDatum | null }> = ({ oven }) => {
     }
   }, [delegator, oven?.value.address, t, toast]);
 
+  const isInputValid = (inputValue: any) => {
+    const exists = options?.find((option) => option.value === inputValue) !== undefined;
+    const valid = inputValue.match(/^(tz1|tz2)([A-Za-z0-9]{33})$/);
+    // TODO: show validation errors somewhere?
+    return valid && !exists;
+  };
+
   const bakerCard = useMemo(() => {
     if (baker) {
       return (
@@ -122,6 +130,15 @@ const BakerInfo: React.FC<{ oven: AllOvenDatum | null }> = ({ oven }) => {
     return <SkeletonLayout count={1} component="AddressCard" />;
   }, [baker]);
 
+  const Option = (props: OptionProps<any>) => {
+    const address = props.data.value;
+    return (
+      <CopyAddress address={address}>
+        <components.Option {...props} />
+      </CopyAddress>
+    );
+  };
+
   const editBakerCard = useMemo(() => {
     if (edit) {
       return (
@@ -133,8 +150,10 @@ const BakerInfo: React.FC<{ oven: AllOvenDatum | null }> = ({ oven }) => {
               setDelegatorValue(ev);
             }}
             options={options}
+            isValidNewOption={isInputValid}
             onCreateOption={handleCreate}
             value={bakerValue}
+            components={{ Option }}
           />
 
           <Flex justifyContent="right">

--- a/frontend/app/src/components/header/Header.tsx
+++ b/frontend/app/src/components/header/Header.tsx
@@ -24,7 +24,6 @@ export const Header: React.FC<IHeaderProps> = ({ handleToggled, toggled }) => {
   const { colorMode, toggleColorMode } = useColorMode();
   const headerBackground = useColorModeValue('white', 'cardbgdark');
   const location = useLocation();
-  // const [headerText, setHeaderText] = useState<string | null>(null);
   const [headerIconText, setHeaderIconText] = useState<HeaderIconText>({ text: null, icon: null });
 
   const setHeader = (pathName: string) => {
@@ -68,6 +67,10 @@ export const Header: React.FC<IHeaderProps> = ({ handleToggled, toggled }) => {
     }
   };
 
+  const isFrontpage = () => {
+    return location.pathname === '/';
+  };
+
   useEffect(() => {
     const pathName = location.pathname;
     setHeader(pathName);
@@ -75,7 +78,11 @@ export const Header: React.FC<IHeaderProps> = ({ handleToggled, toggled }) => {
 
   return (
     <div>
-      <Flex padding="16px" alignItems="center" background={headerBackground}>
+      <Flex
+        padding="16px"
+        alignItems="center"
+        background={!isFrontpage() ? headerBackground : undefined}
+      >
         <Button
           border="1px solid rgba(0, 0, 0, 0.07)"
           backgroundColor="transparent"

--- a/frontend/app/src/components/input/DepositorsInput.tsx
+++ b/frontend/app/src/components/input/DepositorsInput.tsx
@@ -12,7 +12,7 @@ import {
   Wrap,
   WrapItem,
 } from '@chakra-ui/react';
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { IoMdCloseCircle } from 'react-icons/io';
 import { trimAddress } from '../../utils/addressUtils';
 
@@ -42,6 +42,19 @@ const DepositorsInput: React.FC<IDepositorsInputProps> = (props) => {
       setDepositorInput(depositors[1]);
     } else {
       setDepositorInput(depositors[0]);
+    }
+  };
+
+  const onSubmitDepositorInput = () => {
+    if (
+      depositorInput.match(/^(tz1|tz2)([A-Za-z0-9]{33})$/) &&
+      !props.depositors.some((x) => x.value === depositorInput)
+    ) {
+      props.onChange([
+        ...props.depositors,
+        { label: trimAddress(depositorInput), value: depositorInput },
+      ]);
+      setDepositorInput('');
     }
   };
 
@@ -93,10 +106,15 @@ const DepositorsInput: React.FC<IDepositorsInputProps> = (props) => {
           name="depositorInput"
           id="depositorInput"
           value={depositorInput}
-          onChange={handleDepositorInput}
+          onKeyPress={(event) => {
+            if (event.key === 'Enter') {
+              onSubmitDepositorInput();
+            }
+          }}
+          onChange={(event) => setDepositorInput(event.target.value)}
         />
         <Text fontSize="xs" color="#4E5D78">
-          Enter space to whitelist depositor
+          Press return to whitelist depositor
         </Text>
       </FormControl>
     </Box>


### PR DESCRIPTION
Removed background of header on frontpage
added validation to address input fields (need some way to display validation errors there)
adding depositors now listens to pressing enter and only allows 1 address at a time.